### PR TITLE
Upgrades githubstats to 3.0.2, bumps version

### DIFF
--- a/githubchart.gemspec
+++ b/githubchart.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files  = `git ls-files spec/*`.split
   s.executables = ['githubchart']
 
-  s.add_runtime_dependency 'githubstats', '~> 3.0.0'
+  s.add_runtime_dependency 'githubstats', '~> 3.0.2'
   s.add_runtime_dependency 'svgplot', '~> 1.0.0'
 
   s.add_development_dependency 'rubocop', '~> 0.76.0'

--- a/lib/githubchart/version.rb
+++ b/lib/githubchart/version.rb
@@ -1,5 +1,5 @@
 ##
 # Define the version
 module GithubChart
-  VERSION = '3.1.0'.freeze
+  VERSION = '3.1.1'.freeze
 end


### PR DESCRIPTION
Following up upstream from githubstats, this upgrades githubchart to use the latest version